### PR TITLE
v0.3.0.3-alpha updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,30 +18,38 @@ run_ompa_given_config path/to/the/config/file.txt
 The configuration file specifies all the settings about where to find the observations .csv, the end-members .csv, which parameters to use, etc. An example configuration file is pasted below:
 
 ```
-#Comments can be added to the configuration file using the hashtag symbol (#). Anything following the
-# hashtag is ignored. FYI, the 'type' of configuration file used by pyompa is a TOML configuration file
-# (don't worry if you don't know what that means). The main thing to note is that sections in this type
+#Comments can be added to the configuration file using the hashtag symbol (#).
+# Anything following the hashtag is ignored. FYI, the 'type' of configuration
+# file used by pyompa is a TOML configuration file (don't worry if you don't
+# know what that means). The main thing to note is that sections in this type
 # of configuration file are denoted using [section name].
 
-[observations] #this specifies that the next section is going to talk about settings pertaining to the observations file
-#csv_file specifies the path to a .csv file containing the observations. For an example, refer to
+[observations] #this specifies that the next section is going to talk about
+#               settings pertaining to the observations file.
+# csv_file specifies the path to a .csv file containing the observations. For
+# an example, refer to
 # https://github.com/nitrogenlab/GP15_watermassanalysis/blob/988fb74f44b7c62b32c6a11752a9bcbb06471783/gp15_intermediateanddeep_obs.csv
-#The csv_file can have any columns you want, but it must contain column headers corresponding to the parameters you
-# wish to use in the OMPA analysis.
+#The csv_file can have any columns you want, but it must contain column headers
+# corresponding to the parameters you wish to use in the OMPA analysis.
 csv_file = "gp15_intermediateanddeep_obs.csv"
-na_values = -999 #this specifies how "NA" values are denoted in the observations .csv file
+na_values = -999 #this specifies how "NA" values are denoted in the
+#                 observations .csv file
 
 [endmembers]
-#Like the observations file, the endmembers file must have column headers corresponding to the parameters you
-# wish to use in theOMPA analysis. See
+#Like the observations file, the endmembers file must have column headers
+# corresponding to the parameters you wish to use in theOMPA analysis. See
 #https://github.com/nitrogenlab/GP15_watermassanalysis/blob/988fb74f44b7c62b32c6a11752a9bcbb06471783/endmember_df_intermediateanddeep.csv
 # for an example
-csv_file = "endmember_df_intermediateanddeep.csv" #this is a path to a .csv file containing the end-members.
-endmember_name_column = "endmember_name" #what is the header of the column specifying the endmember names.
+csv_file = "endmember_df_intermediateanddeep.csv" #this is a path to a .csv
+#                                                  file containing the
+#                                                  end-members.
+endmember_name_column = "watermass_name" #what is the header of the column
+#                                         specifying the endmember names.
 
-#If a parameter is specified with params.xxxx, then xxxx must correspond to a column header
-# in both the observations and the end-members .csv file
-[params.potential_temp] #This specifies that "potential_temp" will be a parameter used in the OMPA analysis
+#If a parameter is specified with params.xxxx, then xxxx must correspond to a
+# column header in both the observations and the end-members .csv file
+[params.potential_temp] #This specifies that "potential_temp" will be a
+#                        parameter used in the OMPA analysis
 weight = 56.0
 remineralized = false
 
@@ -55,11 +63,18 @@ remineralized = false
 
 [params.nitrate]
 weight = 5.0
-remineralized = true #remineralized parameters must be specified using remineralized=true
-# Remineralized parameters also need the remineralization ratios to be specified.
-# TODO: figure out how to explain these ratios better...these are the ratios relative to oxygen, but
-# with a sign-flip, and also the rows are 'coupled', and the effective remineralization ratio is
-# somwhere within the convex hull of the specified redifield ratios.
+remineralized = true #remineralized parameters must be specified using
+#                     remineralized=true
+#Remineralized parameters also need the remineralization ratios to be specified.
+#TODO: figure out how to explain these ratios better...these are the ratios
+# relative to oxygen, but with a sign-flip, and also the rows are 'coupled',
+# meaning that you put the rows for nitrate/phosphate/oxygen one below the
+# other and then look at each column to get the different redfield ratios
+# specified by each column. That is why each remineralized parameter needs
+# to have the same number of entries under 'ratios', even if the entries
+# are identical. Also, the effective remineralization ratio that is used
+# in the solution for each observation will be somwhere within the convex hull
+# of the redfield ratios specified in this configuration file.
 ratios = [0.10330578512, 0.10330578512]
 
 [params.phosphate]
@@ -70,19 +85,16 @@ ratios = [0.01036168132, 0.00327210989]
 [params.oxygen]
 weight = 1.0
 remineralized = true
-ratios = [-1, -1]
+ratios = [-1, -1] #sign is negative because oxygen is consumed when
+#                  nitrate/phosphate are produced
 
-#If a penalty is specified with endmember_penalties.endmembername.fieldname, then fieldname must be
-# a column header in the observations file and endmembername must be the name of an endmember in the
-# endmembers file.
-#Note: multiple types of penalties (on latitude, on sigma0, etc) can be specified for an endmember;
-# each one would just need to given a section like endmember_penalties.endmembername.fieldname,
-# and the penalties would be added up.
-[endmember_penalties.PSUW.lat]
-type="latlon_default"
-lowerbound = 10
-#'upperbound' can also be specified here if desired.
-
+#If a penalty is specified with endmember_penalties.endmembername.fieldname,
+# then fieldname must be a column header in the observations file and
+# endmembername must be the name of an endmember in the endmembers file.
+#Note: multiple types of penalties (on latitude, on sigma0, etc) can be
+# specified for an endmember; each one would just need to given a section
+# like endmember_penalties.endmembername.fieldname, and the penalties would
+# be added up under-the-hood.
 [endmember_penalties.LCDW.sigma0]
 type="density_default"
 lowerbound = 27.72
@@ -91,16 +103,42 @@ lowerbound = 27.72
 type="density_default"
 lowerbound = 27.72
 
+[endmember_penalties.PSUW.lat]
+type="latlon_default"
+lowerbound = 10
+#'upperbound' can also be specified here if desired.
+
+#type="latlon_default" and type="density_default" specify default values for
+# the shape of the exponential function used to impose the penalty. These
+# are determined by 'alpha', which controls the rate of exponential increase,
+# and 'beta' which is a linear scaling of the penalty. The default values
+# of alpha and beta can be overridden. You can also set type="other", which
+# specifies no defaults for alpha and beta and forces the user to
+# provide both.
+[endmember_penalties.PSUW.depth]
+type="other"
+upperbound = 3000
+alpha=0.001 #controls rate of exponential increase
+beta=50 #linearly scales penalty
+
 #Settings specifiying how to export the results
 [export]
 csv_output_name="ompa_soln.csv"
-orig_cols_to_include = ["lat", "lon", "depth", "stnnbr", "geotrc_ID"] #columns from the obs_df you want repeated in the output
-export_orig_param_vals=false #whether to repeat the original parameter values.
-export_residuals=true
-export_endmember_fracs=true
-export_oxygen_deficit=true
-export_conversion_ratios=true
-export_endmember_usage_penalties=true
+orig_cols_to_include = ["lat", "lon", "depth", "stnnbr", "geotrc_ID"] #columns
+#                              from the obs_df you want repeated in the output
+export_orig_param_vals=true #whether to repeat the original parameter values.
+export_residuals=true #residuals are observed-reconstructed. Columns will have
+#                      the title "[parametername]_resid"
+export_endmember_fracs=true #the endmember fractional compositions. Columns
+#                            will have the title "[endmembername]_frac"
+export_oxygen_deficit=true #the oxygen deficit used when doing the OMPA fit.
+#                           Column will have the title "total_oxygen_deficit"
+export_conversion_ratios=true #the effective remineralization ratio used when
+#                              doing the OMPA fit. Columns will have the
+#                              name "oxygen_to_[paramname]_ratio".
+export_endmember_usage_penalties=true #whether to include the penalty function
+#                                      that ended up being used. Columns will
+#                                      have the title "[endmembername]_penalty"
 ```
 
 ## Running from a colab notebook/in python

--- a/pyompa/__init__.py
+++ b/pyompa/__init__.py
@@ -4,7 +4,7 @@ from .thermocline_array import ThermoclineArrayOMPAProblem
 from .endmemberpenaltyfunc import EndMemExpPenaltyFunc
 from .plotting import (plot_ompasoln_endmember_fractions,
                        plot_ompasoln_residuals,
-                       plot_ompaproblem_endmember_usagepenalties,
+                       plot_ompasoln_endmember_usagepenalties,
                        plot_thermocline_endmember_fractions,
                        plot_thermocline_residuals,
                        build_altair_viz, build_thermocline_altair_viz)

--- a/pyompa/endmemberpenaltyfunc.py
+++ b/pyompa/endmemberpenaltyfunc.py
@@ -23,10 +23,18 @@ def get_default_latlon_exp_penalty_func(alpha=0.05, beta=100, **kwargs):
             alpha=alpha, beta=beta, **kwargs) 
 
 
+#Returns a penalty function that takes an observations data frame as input
+# and outputs the total endmember usage penalty on each observation.
+#colname_to_penaltyfunc is a mapping from a column in the observations data
+# frame to the penalty function associated with that column
 def get_combined_penalty_func(colname_to_penaltyfunc):
     def penalty_func(df):
         total_penalty = None
         for colname, penaltyfunc in colname_to_penaltyfunc.items():
+            assert colname in df, ("An endmember penalty function specified "
+               +str(colname)+" as a column, but no such column is present in"
+               +" the observations data frame; the available column headers"
+               +" in the observations data frame are "+str(df.columns))
             values = np.array(df[colname])
             penalty = penaltyfunc(values) 
             if (total_penalty is None):

--- a/pyompa/ompacore.py
+++ b/pyompa/ompacore.py
@@ -26,6 +26,8 @@ class OMPASoln(object):
         self.obs_df = ompa_problem.obs_df
         self.conserved_params_to_use = ompa_problem.conserved_params_to_use
         self.converted_params_to_use = ompa_problem.converted_params_to_use   
+        self.endmembername_to_usagepenalty =\
+            ompa_problem.endmembername_to_usagepenalty
         self.__dict__.update(kwargs)
 
     def export_to_csv(self, csv_output_name,

--- a/pyompa/ompacore.py
+++ b/pyompa/ompacore.py
@@ -46,6 +46,11 @@ class OMPASoln(object):
              self.conserved_params_to_use+self.converted_params_to_use)
 
         for orig_col in orig_cols_to_include:
+            assert orig_col in self.obs_df, (
+             "Export settings asked that "+orig_col+" be copied from the"
+             +" original observations data frame into the output, but"
+             +" no such column header was present in the observations data"
+             +" frame; the column headers are: "+str(self.obs_df.columns)) 
             toexport_df_dict[orig_col] = self.obs_df[orig_col]
 
         if (export_residuals):
@@ -57,7 +62,7 @@ class OMPASoln(object):
         endmembernames=list(self.endmember_df[self.endmember_name_column])
         if (export_endmember_fracs):
             for endmember_idx in range(len(endmembernames)):
-                toexport_df_dict[endmembernames[endmember_idx]] =\
+                toexport_df_dict[endmembernames[endmember_idx]+"_frac"] =\
                     self.endmember_fractions[:,endmember_idx]
 
         if (export_oxygen_deficit and
@@ -77,7 +82,8 @@ class OMPASoln(object):
                     self.ompa_problem.endmembername_to_usagepenalty): 
                     endmember_usagepenalty = (self.ompa_problem.
                                   endmembername_to_usagepenalty[endmembername])
-                    toexport_df_dict[endmembername] = endmember_usagepenalty
+                    toexport_df_dict[endmembername+"_penalty"] =\
+                        endmember_usagepenalty
         
         toexport_df = pd.DataFrame(toexport_df_dict)
         toexport_df.to_csv(csv_output_name, index=False)

--- a/pyompa/parse_config.py
+++ b/pyompa/parse_config.py
@@ -5,7 +5,6 @@ from .ompacore import OMPAProblem
 from .endmemberpenaltyfunc import EndMemExpPenaltyFunc 
 from .util import assert_in, assert_compatible_keys, assert_has_keys
 from collections import OrderedDict
-from .plotting import plot_ompaproblem_endmember_usagepenalties
 import json
 
 
@@ -117,13 +116,6 @@ def run_ompa_given_config(config):
           smoothness_lambda=None,
           endmembername_to_usagepenaltyfunc=
             endmembername_to_usagepenaltyfunc)
-
-    #if (len(endmembername_to_usagepenaltyfunc) > 0):
-    #    print("endmember usage penalties:")
-    #    plot_ompaproblem_endmember_usagepenalties(
-    #        ompa_problem=ompa_problem,
-    #        xaxis_colname=xaxis_colname, yaxis_colname=yaxis_colname,
-    #        flip_y=flip_y)
 
     ompa_soln = ompa_problem.solve(
               endmember_df=endmember_df,

--- a/pyompa/parse_config.py
+++ b/pyompa/parse_config.py
@@ -42,6 +42,10 @@ def parse_endmembers_config(config):
         parse_df_from_config(config=config, config_file_type="endmembers")
     endmember_name_column = config["endmember_name_column"]
 
+    assert endmember_name_column in endmembers_df,(
+        endmember_name_column+" needs to be present in endmembers_df; "
+        +"the columns are "+str(endmembers_df.columns))
+
     return endmembers_df, endmember_name_column
 
 
@@ -123,7 +127,7 @@ def run_ompa_given_config(config):
 
     ompa_soln = ompa_problem.solve(
               endmember_df=endmember_df,
-              endmember_name_column="endmember_name") 
+              endmember_name_column=endmember_name_column) 
 
     if "export" in config:
         ompa_soln.export_to_csv(**config["export"])
@@ -131,5 +135,18 @@ def run_ompa_given_config(config):
     return ompa_soln
 
 
+def run_given_config_files(config_files, parser, func_to_run):
+    assert len(config_files) > 0, "At least one config file must be supplied"
+    concatenated_file_contents =\
+        "\n".join(open(x).read() for x in config_files) 
+    return func_to_run(parser.loads(concatenated_file_contents)) 
+
+
+def run_ompa_given_toml_config_files(toml_config_files):
+    return run_given_config_files(
+               config_files=toml_config_files,
+               parser=toml, func_to_run=run_ompa_given_config)
+
+
 def run_ompa_given_toml_config_file(toml_config_file):
-    return run_ompa_given_config(toml.loads(open(toml_config_file).read()))
+    return run_ompa_given_toml_config_files([toml_config_file])

--- a/pyompa/plotting.py
+++ b/pyompa/plotting.py
@@ -60,10 +60,13 @@ def plot_endmember_fractions(xaxis_vals, xaxis_label, yaxis_vals, yaxis_label,
         plt.title(endmembernames[i])
     if (total_oxygen_deficit is not None):
         plt.sca(ax[num_endmembers])
-        plt.scatter(xaxis_vals, yaxis_vals, c=total_oxygen_deficit)
+        plt.scatter(xaxis_vals, yaxis_vals, c=total_oxygen_deficit,
+                    cmap="RdBu")
+        max_abs_deficit = np.max(np.abs(total_oxygen_deficit))
         if (flip_y):
             plt.ylim(plt.ylim()[1], plt.ylim()[0])
         plt.colorbar()
+        plt.clim(-max_abs_deficit, max_abs_deficit)
         plt.xlabel(xaxis_label)
         plt.title("oxygen deficit")
     for i in range(len(converted_param_names)):
@@ -101,11 +104,13 @@ def plot_residuals(param_residuals, param_names, xaxis_vals, xaxis_label,
     fig, ax = plt.subplots(nrows=1, ncols=num_params, figsize=(5*num_params,4))
     for i in range(param_residuals.shape[1]):
         plt.sca(ax[i])
+        param_resid_maxabs = np.max(np.abs(param_residuals[:,i]))
         plt.scatter(x=xaxis_vals,
                     y=yaxis_vals,
-                    c=np.abs(param_residuals[:,i]),
-                    cmap="viridis")
+                    c=param_resid_maxabs,
+                    cmap="RdBu")
         plt.colorbar()
+        plt.clim(-param_resid_maxabs, param_resid_maxabs)
         plt.xlabel(xaxis_label)
         if (i==0):
             plt.ylabel(yaxis_label)

--- a/pyompa/plotting.py
+++ b/pyompa/plotting.py
@@ -107,7 +107,7 @@ def plot_residuals(param_residuals, param_names, xaxis_vals, xaxis_label,
         param_resid_maxabs = np.max(np.abs(param_residuals[:,i]))
         plt.scatter(x=xaxis_vals,
                     y=yaxis_vals,
-                    c=param_resid_maxabs,
+                    c=param_residuals[:,i],
                     cmap="RdBu")
         plt.colorbar()
         plt.clim(-param_resid_maxabs, param_resid_maxabs)

--- a/pyompa/plotting.py
+++ b/pyompa/plotting.py
@@ -26,14 +26,14 @@ def plot_endmember_usagepenalties(endmembername_to_usagepenalty,
     plt.show()
 
 
-def plot_ompaproblem_endmember_usagepenalties(
-        ompa_problem, xaxis_colname, yaxis_colname, flip_y=True):
+def plot_ompasoln_endmember_usagepenalties(
+        ompa_soln, xaxis_colname, yaxis_colname, flip_y=True):
     plot_endmember_usagepenalties(
         endmembername_to_usagepenalty=
-            ompa_problem.endmembername_to_usagepenalty,
-        xaxis_vals=ompa_problem.obs_df[xaxis_colname],
+            ompa_soln.endmembername_to_usagepenalty,
+        xaxis_vals=ompa_soln.obs_df[xaxis_colname],
         xaxis_label=xaxis_colname,
-        yaxis_vals=ompa_problem.obs_df[yaxis_colname],
+        yaxis_vals=ompa_soln.obs_df[yaxis_colname],
         yaxis_label=yaxis_colname,
         flip_y=True)
 

--- a/scripts/run_ompa_given_config
+++ b/scripts/run_ompa_given_config
@@ -1,15 +1,17 @@
 #!/usr/bin/env python
 import argparse
 import toml
-from pyompa.parse_config import run_ompa_given_toml_config_file
+from pyompa.parse_config import run_ompa_given_toml_config_files
 
 
 def main(args):
-    run_ompa_given_toml_config_file(args.config_file)
+    run_ompa_given_toml_config_files(args.config_files)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("config_file", help="Configuration file")
+    parser.add_argument("config_files", nargs="+",
+     help=("Configuration file(s); multiple files will be "
+           +"concatenated together"))
     main(parser.parse_args())
     

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if __name__== '__main__':
           author="Avanti Shrikumar",
           author_email="avanti.shrikumar@gmail.com",
           url='https://github.com/nitrogenlab/pyompa',
-          version='0.3.0.2',
+          version='0.3.0.3',
           packages=find_packages(),
           setup_requires=[],
           install_requires=['numpy', 'pandas', 'cvxpy', 'scipy', 'toml'],


### PR DESCRIPTION
Fixes:
- Fixed bug where column with endmember names had to be called "endmember_name"
- More informative error messages

New features:
- Can take in a list of configuration files (which are concatenated under the hood)
- plot_ompaproblem_endmember_usagepenalties now called plot_ompasoln_endmember_usagepenalties, and can accept an ompasoln object
- Plot of oxygen deficit as well as the plot of parmameter residuals use a diverging colormap; actual parameter residuals (not just absolute value) are now plotted.

Notebook: https://colab.research.google.com/github/nitrogenlab/GP15_watermassanalysis/blob/668c8694ca06844cff6a40b172425acdecd91ef9/dev_config_files_demo.ipynb