### PR TITLE
v0.3.1.0

### DIFF
--- a/pyompa/__init__.py
+++ b/pyompa/__init__.py
@@ -8,3 +8,4 @@ from .plotting import (plot_ompasoln_endmember_fractions,
                        plot_thermocline_endmember_fractions,
                        plot_thermocline_residuals,
                        build_altair_viz, build_thermocline_altair_viz)
+from .parse_config import run_ompa_given_toml_config_file

--- a/pyompa/endmemberpenaltyfunc.py
+++ b/pyompa/endmemberpenaltyfunc.py
@@ -58,6 +58,7 @@ class EndMemExpPenaltyFunc(object):
     SPECTYPE_TO_FACTORYFUNC = {
         'density_default': get_default_density_exp_penalty_func,
         'latlon_default': get_default_latlon_exp_penalty_func,
+        'depth_default': get_default_depth_exp_penalty_func,
         'other': get_exponential_from_bounds_func}
 
     def __init__(self, spec):

--- a/pyompa/endmemberpenaltyfunc.py
+++ b/pyompa/endmemberpenaltyfunc.py
@@ -23,6 +23,12 @@ def get_default_latlon_exp_penalty_func(alpha=0.05, beta=100, **kwargs):
             alpha=alpha, beta=beta, **kwargs) 
 
 
+#same as get_exponential_from_bounds_func but with defaults for alpha and beta
+def get_default_depth_exp_penalty_func(alpha=0.001, beta=50, **kwargs):
+    return get_exponential_from_bounds_func(
+            alpha=alpha, beta=beta, **kwargs) 
+
+
 #Returns a penalty function that takes an observations data frame as input
 # and outputs the total endmember usage penalty on each observation.
 #colname_to_penaltyfunc is a mapping from a column in the observations data

--- a/pyompa/ompacore.py
+++ b/pyompa/ompacore.py
@@ -118,7 +118,6 @@ class OMPAProblem(object):
         self.endmembername_to_usagepenaltyfunc =\
           endmembername_to_usagepenaltyfunc
         self.process_params()
-        self.drop_na_rows()
         self.prep_endmember_usagepenalties() 
 
 

--- a/pyompa/ompacore.py
+++ b/pyompa/ompacore.py
@@ -185,7 +185,8 @@ class OMPAProblem(object):
             if endmembername not in endmember_names:
                 print("WARNING!!! You specified a usage penalty for "
                  +str(endmembername)+" but that endmember did not appear "
-                 +"in the endmember data frame")
+                 +"in the endmember data frame; endmembers are "
+                 +str(endmember_names))
                  
         return endmember_usagepenalty
 

--- a/pyompa/ompacore.py
+++ b/pyompa/ompacore.py
@@ -141,7 +141,7 @@ class OMPAProblem(object):
                  +" observations data frame columns are "
                  +str(list(self.obs_df.columns)))
 
-        with_drop_na = (self.obs_df[param_names]).dropna()
+        with_drop_na = self.obs_df.dropna(subset=param_names)
         if (len(with_drop_na) < len(self.obs_df)):
             print("Dropping "+str(len(self.obs_df)-len(with_drop_na))
                   +" rows that have NA values in the observations")

--- a/pyompa/ompacore.py
+++ b/pyompa/ompacore.py
@@ -183,8 +183,8 @@ class OMPAProblem(object):
         #print a warning if specified a usage penalty that was not used
         for endmembername in self.endmembername_to_usagepenalty:
             if endmembername not in endmember_names:
-                print("WARNING!!! You specified a usage penalty for "
-                 +str(endmembername)+" but that endmember did not appear "
+                raise RuntimeError("You specified a usage penalty for "
+                 +endmembername+" but that endmember did not appear "
                  +"in the endmember data frame; endmembers are "
                  +str(endmember_names))
                  

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if __name__== '__main__':
           author="Avanti Shrikumar",
           author_email="avanti.shrikumar@gmail.com",
           url='https://github.com/nitrogenlab/pyompa',
-          version='0.3.0.3',
+          version='0.3.1.0',
           packages=find_packages(),
           setup_requires=[],
           install_requires=['numpy', 'pandas', 'cvxpy', 'scipy', 'toml'],


### PR DESCRIPTION
- Added support for "depth_default" in the penalty functions
- Rows with na values in the parameter columns for the observations are automatically dropped
- If an endmember name for which a usage penalty is specified is not in the endmembers df, an error now gets thrown